### PR TITLE
update exiftool version. add ZIP support to exiftool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN groupadd -r malice \
   && chown -R malice:malice /malware
 
 ENV SSDEEP 2.14.1
-ENV EXIFTOOL 11.65
+ENV EXIFTOOL 12.02
 
 RUN buildDeps='ca-certificates \
   build-essential \
@@ -38,7 +38,7 @@ RUN buildDeps='ca-certificates \
   curl' \
   && set -x \
   && apt-get update -qq \
-  && apt-get install -yq --no-install-recommends $buildDeps libmagic-dev libc6 \
+  && apt-get install -yq --no-install-recommends $buildDeps libmagic-dev libc6 cpanminus \
   && echo "Downloading TRiD and Database..." \
   && curl -Ls http://mark0.net/download/trid_linux_64.zip > /tmp/trid_linux_64.zip \
   && curl -Ls http://mark0.net/download/triddefs.zip > /tmp/triddefs.zip \
@@ -58,7 +58,8 @@ RUN buildDeps='ca-certificates \
   && make \
   && make install \
   && echo "Installing exiftool..." \
-  && curl -Ls https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-$EXIFTOOL.tar.gz > \
+  && cpanm --notest File::Find Archive::Zip Compress::Raw::Zlib \
+  && curl -Ls https://exiftool.org/Image-ExifTool-$EXIFTOOL.tar.gz> \
   /tmp/exiftool.tar.gz \
   && cd /tmp \
   && tar xzf exiftool.tar.gz \


### PR DESCRIPTION
Taking a stab at resolving #9. 

### Changes
* Update Exiftool version to 12.02
* Update Exiftool download path
* Add cpanminus and install zip libraries to enable decompression capabilities for Exiftool

Regarding @tomerf-sndbox's point on adding compression capabilities it is indeed very beneficial, below is example output against a maldoc. When Exiftool is able to decompress the document, much more metadata can be extracted.

<details>
   <summary>Output without decompression</summary>

  ```json
  {
  "magic": {
    "mime": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
    "description": "Microsoft Word 2007+"
  },
  "ssdeep": "3072:deLW16bdRfBUjNa92ypWbHie8p9D9ivLsm0206BUNg:dpUUjNa9pyHiN8Tsm0206f",
  "trid": [
     "53.0% (.DOCM) Word Microsoft Office Open XML Format document (with Macro) (52000/1/9)",
     "23.9% (.DOCX) Word Microsoft Office Open XML Format document (23500/1/4)",
     "17.8% (.ZIP) Open Packaging Conventions container (17500/1/4)",
     "4.0% (.ZIP) ZIP compressed archive (4000/1)",
     "1.0% (.BIN) PrintFox/Pagefox bitmap (var. P) (1000/1)"
  ],
  "exiftool": {
    "ExifToolVersionNumber": "11.11",
    "FileSize": "110 kB",
    "FileType": "ZIP",
    "FileTypeExtension": "zip",
    "MIMEType": "application/zip",
    "ZipBitFlag": "0x0006",
    "ZipCRC": "0x0c0cc35b",
    "ZipCompressedSize": "400",
    "ZipCompression": "Deflated",
    "ZipFileName": "[Content_Types].xml",
    "ZipRequiredVersion": "20",
    "ZipUncompressedSize": "1505"
  }
}
  ```
  </details>

<details>
   <summary>Output with decompression</summary>

  ```json
  {
  "magic": {
    "mime": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
    "description": "Microsoft Word 2007+"
  },
  "ssdeep": "3072:deLW16bdRfBUjNa92ypWbHie8p9D9ivLsm0206BUNg:dpUUjNa9pyHiN8Tsm0206f",
  "trid": [
     "53.0% (.DOCM) Word Microsoft Office Open XML Format document (with Macro) (52000/1/9)",
     "23.9% (.DOCX) Word Microsoft Office Open XML Format document (23500/1/4)",
     "17.8% (.ZIP) Open Packaging Conventions container (17500/1/4)",
     "4.0% (.ZIP) ZIP compressed archive (4000/1)",
     "1.0% (.BIN) PrintFox/Pagefox bitmap (var. P) (1000/1)"
  ],
  "exiftool": {
    "AppVersion": "16.0000",
    "Application": "Microsoft Office Word",
    "Category": "",
    "Characters": "0",
    "CharactersWithSpaces": "0",
    "Company": "",
    "Creator": "czhljm",
    "Description": "",
    "DocSecurity": "None",
    "ExifToolVersionNumber": "12.02",
    "FileSize": "110 kB",
    "FileType": "DOCM",
    "FileTypeExtension": "docm",
    "HyperlinksChanged": "No",
    "Keywords": "",
    "LastModifiedBy": "Administrator",
    "Lines": "1",
    "LinksUpToDate": "No",
    "MIMEType": "application/vnd.ms-word.document.macroEnabled",
    "Manager": "",
    "Pages": "1",
    "Paragraphs": "0",
    "RevisionNumber": "2",
    "ScaleCrop": "No",
    "SharedDoc": "No",
    "Subject": "",
    "Template": "Normal.dotm",
    "Title": "",
    "TotalEditTime": "0",
    "Words": "0",
    "ZipBitFlag": "0x0006",
    "ZipCRC": "0x0c0cc35b",
    "ZipCompressedSize": "400",
    "ZipCompression": "Deflated",
    "ZipFileName": "[Content_Types].xml",
    "ZipRequiredVersion": "20",
    "ZipUncompressedSize": "1505"
  }
}
  ```
  </details> 